### PR TITLE
upgrade alpine 3.21 and fix user issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.6
+FROM alpine:3.21.3
 MAINTAINER David Personette <mrnim94@gmail.com>
 
 # Install samba

--- a/Dockerfile.not_recycle
+++ b/Dockerfile.not_recycle
@@ -1,4 +1,4 @@
-FROM alpine:3.20.6
+FROM alpine:3.21.3
 MAINTAINER Mr Nim <mr.nim94@gmail.com>
 
 # #https://github.com/kubernetes-csi/csi-driver-smb/issues/79#issuecomment-675325067

--- a/samba.sh
+++ b/samba.sh
@@ -87,7 +87,7 @@ import() { local file="$1" name id
 # Return: result
 perms() { local i file=/etc/samba/smb.conf
     for i in $(awk -F ' = ' '/   path = / {print $2}' $file); do
-        chown -Rh smbuser $i
+        chown -Rh smbuser:smb "$i"
         find $i -type d ! -perm 775 -exec chmod 775 {} \;
         find $i -type f ! -perm 0664 -exec chmod 0664 {} \;
     done

--- a/samba.sh
+++ b/samba.sh
@@ -87,7 +87,7 @@ import() { local file="$1" name id
 # Return: result
 perms() { local i file=/etc/samba/smb.conf
     for i in $(awk -F ' = ' '/   path = / {print $2}' $file); do
-        chown -Rh smbuser. $i
+        chown -Rh smbuser $i
         find $i -type d ! -perm 775 -exec chmod 775 {} \;
         find $i -type f ! -perm 0664 -exec chmod 0664 {} \;
     done


### PR DESCRIPTION
-  Previous versions of the chown utility used the dot ('.') character to distinguish the group name. This has been changed to be a colon (``:'') character, so that user and group names may contain the dot character.  Remove '.' next to smbuser at line 90 (samba.sh).
- Link doc: https://opswat.atlassian.net/wiki/x/JwWV7Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the base image in the Dockerfile to a newer version of Alpine Linux.  
- **Bug Fixes**
  - Corrected ownership assignment for Samba share paths to ensure proper permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->